### PR TITLE
Making nnUNet jit scriptable

### DIFF
--- a/dynamic_network_architectures/architectures/resnet.py
+++ b/dynamic_network_architectures/architectures/resnet.py
@@ -85,7 +85,7 @@ class ResNetD(nn.Module):
                                        norm_op=self.ops['norm_op'], norm_op_kwargs=None, dropout_op=None,
                                        dropout_op_kwargs=None, nonlin=nn.ReLU,
                                        nonlin_kwargs={'inplace': True}, block=self.cfg['block'],
-                                       bottleneck_channels=self.cfg['bottleneck_channels'], return_skips=False,
+                                       bottleneck_channels=self.cfg['bottleneck_channels'],
                                        disable_default_stem=self.cfg['disable_default_stem'],
                                        stem_channels=self.cfg['stem_channels'],
                                        stochastic_depth_p=stochastic_depth_p,
@@ -99,7 +99,7 @@ class ResNetD(nn.Module):
     def forward(self, x):
         if self.stem is not None:
             x = self.stem(x)
-        x = self.encoder(x)
+        x = self.encoder(x)[-1]
         x = self.gap(x)
         x = self.final_layer_dropout(x).squeeze()
 
@@ -226,11 +226,10 @@ if __name__ == '__main__':
     data = torch.rand((1, 3, 224, 224))
 
     model = ResNet50bn(10, 3)
-    import hiddenlayer as hl
+    if False:
+        import hiddenlayer as hl
 
-    g = hl.build_graph(model, data,
-                       transforms=None)
-    g.save("network_architecture.pdf")
-    del g
-
-    #print(model.compute_conv_feature_map_size((32, 32)))
+        g = hl.build_graph(model, data,
+                           transforms=None)
+        g.save("network_architecture.pdf")
+        del g

--- a/dynamic_network_architectures/architectures/unet.py
+++ b/dynamic_network_architectures/architectures/unet.py
@@ -8,7 +8,7 @@ from torch.nn.modules.conv import _ConvNd
 from torch.nn.modules.dropout import _DropoutNd
 
 from dynamic_network_architectures.building_blocks.plain_conv_encoder import PlainConvEncoder
-from dynamic_network_architectures.building_blocks.unet_decoder import UNetDecoder
+from dynamic_network_architectures.building_blocks.unet_decoder import UNetDecoder, UNetDecoderNoDeepSupervision
 from dynamic_network_architectures.building_blocks.helper import convert_conv_op_to_dim
 
 
@@ -48,22 +48,27 @@ class PlainConvUNet(nn.Module):
                                                                 f"as we have resolution stages. here: {n_stages} " \
                                                                 f"stages, so it should have {n_stages - 1} entries. " \
                                                                 f"n_conv_per_stage_decoder: {n_conv_per_stage_decoder}"
-        self.encoder = PlainConvEncoder(input_channels, n_stages, features_per_stage, conv_op, kernel_sizes, strides,
-                                        n_conv_per_stage, conv_bias, norm_op, norm_op_kwargs, dropout_op,
-                                        dropout_op_kwargs, nonlin, nonlin_kwargs, return_skips=True,
-                                        nonlin_first=nonlin_first)
-        self.decoder = UNetDecoder(self.encoder, num_classes, n_conv_per_stage_decoder, deep_supervision,
-                                   nonlin_first=nonlin_first)
+        self.encoder = PlainConvEncoder(input_channels, n_stages, features_per_stage, conv_op, kernel_sizes,
+                                                   strides, n_conv_per_stage, conv_bias, norm_op, norm_op_kwargs,
+                                                   dropout_op, dropout_op_kwargs, nonlin, nonlin_kwargs,
+                                                   nonlin_first=nonlin_first)
+        if deep_supervision:
+            self.decoder = UNetDecoder(self.encoder, num_classes, n_conv_per_stage_decoder, nonlin_first=nonlin_first)
+        else:
+            self.decoder = UNetDecoderNoDeepSupervision(self.encoder, num_classes, n_conv_per_stage_decoder,
+                                                        nonlin_first=nonlin_first)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> Union[torch.Tensor, List[torch.Tensor]]:
         skips = self.encoder(x)
         return self.decoder(skips)
 
     def compute_conv_feature_map_size(self, input_size):
-        assert len(input_size) == convert_conv_op_to_dim(self.encoder.conv_op), "just give the image size without color/feature channels or " \
-                                                            "batch channel. Do not give input_size=(b, c, x, y(, z)). " \
-                                                            "Give input_size=(x, y(, z))!"
-        return self.encoder.compute_conv_feature_map_size(input_size) + self.decoder.compute_conv_feature_map_size(input_size)
+        assert len(input_size) == convert_conv_op_to_dim(
+            self.encoder.conv_op), "just give the image size without color/feature channels or " \
+                                   "batch channel. Do not give input_size=(b, c, x, y(, z)). " \
+                                   "Give input_size=(x, y(, z))!"
+        return self.encoder.compute_conv_feature_map_size(input_size) + self.decoder.compute_conv_feature_map_size(
+            input_size)
 
 
 class ResidualEncoderUNet(nn.Module):
@@ -95,8 +100,8 @@ class ResidualEncoderUNet(nn.Module):
         if isinstance(n_conv_per_stage_decoder, int):
             n_conv_per_stage_decoder = [n_conv_per_stage_decoder] * (n_stages - 1)
         assert len(n_blocks_per_stage) == n_stages, "n_blocks_per_stage must have as many entries as we have " \
-                                                  f"resolution stages. here: {n_stages}. " \
-                                                  f"n_blocks_per_stage: {n_blocks_per_stage}"
+                                                    f"resolution stages. here: {n_stages}. " \
+                                                    f"n_blocks_per_stage: {n_blocks_per_stage}"
         assert len(n_conv_per_stage_decoder) == (n_stages - 1), "n_conv_per_stage_decoder must have one less entries " \
                                                                 f"as we have resolution stages. here: {n_stages} " \
                                                                 f"stages, so it should have {n_stages - 1} entries. " \
@@ -104,25 +109,30 @@ class ResidualEncoderUNet(nn.Module):
         self.encoder = ResidualEncoder(input_channels, n_stages, features_per_stage, conv_op, kernel_sizes, strides,
                                        n_blocks_per_stage, conv_bias, norm_op, norm_op_kwargs, dropout_op,
                                        dropout_op_kwargs, nonlin, nonlin_kwargs, block, bottleneck_channels,
-                                       return_skips=True, disable_default_stem=False, stem_channels=stem_channels)
-        self.decoder = UNetDecoder(self.encoder, num_classes, n_conv_per_stage_decoder, deep_supervision)
+                                       disable_default_stem=False, stem_channels=stem_channels)
+        if deep_supervision:
+            self.decoder = UNetDecoder(self.encoder, num_classes, n_conv_per_stage_decoder)
+        else:
+            self.decoder = UNetDecoderNoDeepSupervision(self.encoder, num_classes, n_conv_per_stage_decoder)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> Union[torch.Tensor, List[torch.Tensor]]:
         skips = self.encoder(x)
         return self.decoder(skips)
 
     def compute_conv_feature_map_size(self, input_size):
-        assert len(input_size) == convert_conv_op_to_dim(self.encoder.conv_op), "just give the image size without color/feature channels or " \
-                                                                                "batch channel. Do not give input_size=(b, c, x, y(, z)). " \
-                                                                                "Give input_size=(x, y(, z))!"
-        return self.encoder.compute_conv_feature_map_size(input_size) + self.decoder.compute_conv_feature_map_size(input_size)
+        assert len(input_size) == convert_conv_op_to_dim(
+            self.encoder.conv_op), "just give the image size without color/feature channels or " \
+                                   "batch channel. Do not give input_size=(b, c, x, y(, z)). " \
+                                   "Give input_size=(x, y(, z))!"
+        return self.encoder.compute_conv_feature_map_size(input_size) + self.decoder.compute_conv_feature_map_size(
+            input_size)
 
 
 if __name__ == '__main__':
     data = torch.rand((1, 4, 128, 128, 128))
 
     model = PlainConvUNet(4, 6, (32, 64, 125, 256, 320, 320), nn.Conv3d, 3, (1, 2, 2, 2, 2, 2), (2, 2, 2, 2, 2, 2), 4,
-                                (2, 2, 2, 2, 2), False, nn.BatchNorm3d, None, None, None, nn.ReLU, deep_supervision=True)
+                          (2, 2, 2, 2, 2), False, nn.BatchNorm3d, None, None, None, nn.ReLU, deep_supervision=True)
 
     if False:
         import hiddenlayer as hl
@@ -136,8 +146,10 @@ if __name__ == '__main__':
 
     data = torch.rand((1, 4, 512, 512))
 
-    model = PlainConvUNet(4, 8, (32, 64, 125, 256, 512, 512, 512, 512), nn.Conv2d, 3, (1, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2, 2, 2, 2, 2), 4,
-                                (2, 2, 2, 2, 2, 2, 2), False, nn.BatchNorm2d, None, None, None, nn.ReLU, deep_supervision=True)
+    model = PlainConvUNet(4, 8, (32, 64, 125, 256, 512, 512, 512, 512), nn.Conv2d, 3, (1, 2, 2, 2, 2, 2, 2, 2),
+                          (2, 2, 2, 2, 2, 2, 2, 2), 4,
+                          (2, 2, 2, 2, 2, 2, 2), False, nn.BatchNorm2d, None, None, None, nn.ReLU,
+                          deep_supervision=True)
 
     if False:
         import hiddenlayer as hl

--- a/dynamic_network_architectures/architectures/vgg.py
+++ b/dynamic_network_architectures/architectures/vgg.py
@@ -37,13 +37,12 @@ class VGG(nn.Module):
             conv_op=ops['conv_op'],
             kernel_sizes=3, strides=cfg['strides'], n_conv_per_stage=cfg['n_conv_per_stage'], conv_bias=False,
             norm_op=ops['norm_op'], norm_op_kwargs=None, dropout_op=None, dropout_op_kwargs=None, nonlin=nn.ReLU,
-            nonlin_kwargs={'inplace': True}, return_skips=False
-        )
+            nonlin_kwargs={'inplace': True})
         self.gap = get_matching_pool_op(conv_op=ops['conv_op'], adaptive=True, pool_type='avg')(1)
         self.classifier = nn.Linear(cfg['features_per_stage'][-1], n_classes, True)
 
     def forward(self, x):
-        x = self.encoder(x)
+        x = self.encoder(x)[-1]
         x = self.gap(x).squeeze()
         return self.classifier(x)
 
@@ -75,11 +74,12 @@ if __name__ == '__main__':
     data = torch.rand((1, 3, 32, 32))
 
     model = VGG19_cifar(10, 3)
-    import hiddenlayer as hl
+    if False:
+        import hiddenlayer as hl
 
-    g = hl.build_graph(model, data,
-                       transforms=None)
-    g.save("network_architecture.pdf")
-    del g
+        g = hl.build_graph(model, data,
+                           transforms=None)
+        g.save("network_architecture.pdf")
+        del g
 
     print(model.compute_conv_feature_map_size((32, 32)))

--- a/dynamic_network_architectures/building_blocks/plain_conv_encoder.py
+++ b/dynamic_network_architectures/building_blocks/plain_conv_encoder.py
@@ -25,11 +25,8 @@ class PlainConvEncoder(nn.Module):
                  dropout_op_kwargs: dict = None,
                  nonlin: Union[None, Type[torch.nn.Module]] = None,
                  nonlin_kwargs: dict = None,
-                 return_skips: bool = False,
                  nonlin_first: bool = False,
-                 pool: str = 'conv'
-                 ):
-
+                 pool: str = 'conv'):
         super().__init__()
         if isinstance(kernel_sizes, int):
             kernel_sizes = [kernel_sizes] * n_stages
@@ -67,7 +64,6 @@ class PlainConvEncoder(nn.Module):
         self.stages = nn.Sequential(*stages)
         self.output_channels = features_per_stage
         self.strides = [maybe_convert_scalar_to_list(conv_op, i) for i in strides]
-        self.return_skips = return_skips
 
         # we store some things that a potential decoder needs
         self.conv_op = conv_op
@@ -80,15 +76,12 @@ class PlainConvEncoder(nn.Module):
         self.conv_bias = conv_bias
         self.kernel_sizes = kernel_sizes
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
         ret = []
         for s in self.stages:
             x = s(x)
             ret.append(x)
-        if self.return_skips:
-            return ret
-        else:
-            return ret[-1]
+        return ret
 
     def compute_conv_feature_map_size(self, input_size):
         output = np.int64(0)
@@ -101,5 +94,4 @@ class PlainConvEncoder(nn.Module):
                 output += self.stages[s].compute_conv_feature_map_size(input_size)
             input_size = [i // j for i, j in zip(input_size, self.strides[s])]
         return output
-
 

--- a/dynamic_network_architectures/building_blocks/regularization.py
+++ b/dynamic_network_architectures/building_blocks/regularization.py
@@ -1,7 +1,9 @@
+import torch
 from torch import nn
 
 
-def drop_path(x, drop_prob: float = 0., training: bool = False, scale_by_keep: bool = True):
+def drop_path(x: torch.Tensor, drop_prob: float = 0., training: bool = False,
+              scale_by_keep: bool = True) -> torch.Tensor:
     """
     This function is taken from the timm package (https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/layers/drop.py).
 
@@ -28,12 +30,13 @@ class DropPath(nn.Module):
 
     Drop paths (Stochastic Depth) per sample  (when applied in main path of residual blocks).
     """
+
     def __init__(self, drop_prob: float = 0., scale_by_keep: bool = True):
         super(DropPath, self).__init__()
         self.drop_prob = drop_prob
         self.scale_by_keep = scale_by_keep
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return drop_path(x, self.drop_prob, self.training, self.scale_by_keep)
 
 
@@ -50,6 +53,7 @@ class SqueezeExcite(nn.Module):
         * global max pooling can be added to the squeeze aggregation
         * customizable activation, normalization, and gate layer
     """
+
     def __init__(
             self, channels, conv_op, rd_ratio=1. / 16, rd_channels=None, rd_divisor=8, add_maxpool=False,
             act_layer=nn.ReLU, norm_layer=None, gate_layer=nn.Sigmoid):
@@ -63,7 +67,7 @@ class SqueezeExcite(nn.Module):
         self.fc2 = conv_op(rd_channels, channels, kernel_size=1, bias=True)
         self.gate = gate_layer()
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x_se = x.mean((2, 3), keepdim=True)
         if self.add_maxpool:
             # experimental codepath, may remove or change

--- a/dynamic_network_architectures/building_blocks/residual.py
+++ b/dynamic_network_architectures/building_blocks/residual.py
@@ -71,7 +71,7 @@ class BasicBlockD(nn.Module):
         self.conv2 = ConvDropoutNormReLU(conv_op, output_channels, output_channels, kernel_size, 1, conv_bias, norm_op,
                                          norm_op_kwargs, None, None, None, None)
 
-        self.nonlin2 = nonlin(**nonlin_kwargs) if nonlin is not None else lambda x: x
+        self.nonlin2 = nonlin(**nonlin_kwargs) if nonlin is not None else nn.Identity()
 
         # Stochastic Depth
         self.apply_stochastic_depth = False if stochastic_depth_p == 0.0 else True
@@ -99,9 +99,9 @@ class BasicBlockD(nn.Module):
                 )
             self.skip = nn.Sequential(*ops)
         else:
-            self.skip = lambda x: x
+            self.skip = nn.Identity()
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         residual = self.skip(x)
         out = self.conv2(self.conv1(x))
         if self.apply_stochastic_depth:
@@ -196,7 +196,7 @@ class BottleneckD(nn.Module):
         self.conv3 = ConvDropoutNormReLU(conv_op, bottleneck_channels, output_channels, 1, 1, conv_bias, norm_op,
                                          norm_op_kwargs, None, None, None, None)
 
-        self.nonlin3 = nonlin(**nonlin_kwargs) if nonlin is not None else lambda x: x
+        self.nonlin3 = nonlin(**nonlin_kwargs) if nonlin is not None else nn.Identity()
 
         # Stochastic Depth
         self.apply_stochastic_depth = False if stochastic_depth_p == 0.0 else True
@@ -224,9 +224,9 @@ class BottleneckD(nn.Module):
                 )
             self.skip = nn.Sequential(*ops)
         else:
-            self.skip = lambda x: x
+            self.skip = nn.Identity()
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         residual = self.skip(x)
         out = self.conv3(self.conv2(self.conv1(x)))
         if self.apply_stochastic_depth:
@@ -337,7 +337,7 @@ class StackedResidualBlocks(nn.Module):
         self.initial_stride = maybe_convert_scalar_to_list(conv_op, initial_stride)
         self.output_channels = output_channels[-1]
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.blocks(x)
 
     def compute_conv_feature_map_size(self, input_size):
@@ -361,11 +361,12 @@ if __name__ == '__main__':
                                               3, 24, 3, 1, True, nn.BatchNorm2d, {}, None, None, nn.LeakyReLU,
                                               {'inplace': True}),
                           stx)
-    import hiddenlayer as hl
+    if False:
+        import hiddenlayer as hl
 
-    g = hl.build_graph(model, data,
-                       transforms=None)
-    g.save("network_architecture.pdf")
-    del g
+        g = hl.build_graph(model, data,
+                           transforms=None)
+        g.save("network_architecture.pdf")
+        del g
 
     print(stx.compute_conv_feature_map_size((40, 32)))

--- a/dynamic_network_architectures/building_blocks/simple_conv_blocks.py
+++ b/dynamic_network_architectures/building_blocks/simple_conv_blocks.py
@@ -67,7 +67,7 @@ class ConvDropoutNormReLU(nn.Module):
 
         self.all_modules = nn.Sequential(*ops)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.all_modules(x)
 
     def compute_conv_feature_map_size(self, input_size):
@@ -133,7 +133,7 @@ class StackedConvBlocks(nn.Module):
         self.output_channels = output_channels[-1]
         self.initial_stride = maybe_convert_scalar_to_list(conv_op, initial_stride)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.convs(x)
 
     def compute_conv_feature_map_size(self, input_size):
@@ -157,11 +157,12 @@ if __name__ == '__main__':
                                               3, 24, 3, 1, True, nn.BatchNorm2d, {}, None, None, nn.LeakyReLU,
                                               {'inplace': True}),
                           stx)
-    import hiddenlayer as hl
+    if False:
+        import hiddenlayer as hl
 
-    g = hl.build_graph(model, data,
-                       transforms=None)
-    g.save("network_architecture.pdf")
-    del g
+        g = hl.build_graph(model, data,
+                           transforms=None)
+        g.save("network_architecture.pdf")
+        del g
 
-    stx.compute_conv_feature_map_size((40, 32))
+    print(stx.compute_conv_feature_map_size((40, 32)))


### PR DESCRIPTION
* Removed `return_skips` parameter from encoders, now all encoders return skip and the caller decides whether to keep or discard them.
* Reimplemented `UNetDecoder.forward` because dynamic index access is not allowed in TorchScript.
* Moved the *no deepsupervision* implementation into a separate `UNetDecoderNoDeepSupervision` class.
* Replaced all `lambda x: x` with nn.Identity.