### PR TITLE
feat: decouple encoder and decoder

### DIFF
--- a/dynamic_network_architectures/building_blocks/plain_conv_encoder.py
+++ b/dynamic_network_architectures/building_blocks/plain_conv_encoder.py
@@ -27,7 +27,8 @@ class PlainConvEncoder(nn.Module):
                  nonlin_kwargs: dict = None,
                  return_skips: bool = False,
                  nonlin_first: bool = False,
-                 pool: str = 'conv'
+                 pool: str = 'conv',
+                 **kwargs
                  ):
 
         super().__init__()

--- a/dynamic_network_architectures/building_blocks/unet_decoder.py
+++ b/dynamic_network_architectures/building_blocks/unet_decoder.py
@@ -43,7 +43,8 @@ class UNetDecoder(nn.Module):
         """
         super().__init__()
         self.deep_supervision = deep_supervision
-        self.encoder = encoder
+        self.encoder_strides = encoder.strides
+        self.encoder_output_channels = encoder.output_channels
         self.num_classes = num_classes
         n_stages_encoder = len(encoder.output_channels)
         if isinstance(n_conv_per_stage, int):
@@ -133,8 +134,8 @@ class UNetDecoder(nn.Module):
         # first we need to compute the skip sizes. Skip bottleneck because all output feature maps of our ops will at
         # least have the size of the skip above that (therefore -1)
         skip_sizes = []
-        for s in range(len(self.encoder.strides) - 1):
-            skip_sizes.append([i // j for i, j in zip(input_size, self.encoder.strides[s])])
+        for s in range(len(self.encoder_strides) - 1):
+            skip_sizes.append([i // j for i, j in zip(input_size, self.encoder_strides[s])])
             input_size = skip_sizes[-1]
         # print(skip_sizes)
 
@@ -143,11 +144,11 @@ class UNetDecoder(nn.Module):
         # our ops are the other way around, so let's match things up
         output = np.int64(0)
         for s in range(len(self.stages)):
-            # print(skip_sizes[-(s+1)], self.encoder.output_channels[-(s+2)])
+            # print(skip_sizes[-(s+1)], self.encoder_output_channels[-(s+2)])
             # conv blocks
             output += self.stages[s].compute_conv_feature_map_size(skip_sizes[-(s+1)])
             # trans conv
-            output += np.prod([self.encoder.output_channels[-(s+2)], *skip_sizes[-(s+1)]], dtype=np.int64)
+            output += np.prod([self.encoder_output_channels[-(s+2)], *skip_sizes[-(s+1)]], dtype=np.int64)
             # segmentation
             if self.deep_supervision or (s == (len(self.stages) - 1)):
                 output += np.prod([self.num_classes, *skip_sizes[-(s+1)]], dtype=np.int64)


### PR DESCRIPTION
Hello @FabianIsensee, 

thanks for the great work on this and also on nnU-net. For my master thesis, I want to test the effects of self-supervised pretraining on certain datasets based on the nnU-Net model. 

For that, I want to implement pre-training of the encoder in a self-supervised manner. For that, it is absolutely sufficient to load the encoder onto gpu memory, the decoder can stay in cpu as it will not be used in this mode. 

Currently, this behavior of separating encoder to gpu and decoder to cpu is not possible with dynamic-network-architectures, as the encoder is set as a class attribute in the decoder (`self.encoder = encoder`). Whenever I move the decoder to cpu, the encoder is also moved to cpu, as it is a submodule of the decoder through the attribute reference.

Minimal example:

```python
from torch import nn


class MyModel(nn.Module):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.device = "cuda"
        self.encoder = MyEncoder().to(self.device)

        # move this to cpu, as we only need the encoder on gpu and we can use smaller gpus then
        self.decoder = MyDecoder(self.encoder).to("cpu")

    def forward(self, x):
        return self.decoder(self.encoder(x))


class MyEncoder(nn.Module):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.model = nn.Linear(64, 16)

        self.some_arg = 10

    def forward(self, x):
        return self.model(x)


class MyDecoder(nn.Module):
    def __init__(self, encoder, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.model = nn.Linear(16, 64)

        self.encoder = encoder

    def forward(self, x):
        print("some arg", self.encoder.some_arg)
        return self.model(x)


if __name__ == "__main__":
    my_model = MyModel()

    print(next(my_model.decoder.parameters()).device) # this is on cpu as expected
    print(next(my_model.encoder.parameters()).device) # this is also on cpu because of coupling :((
```

If we avoid the coupling between encoder and decoder, I am able to only load the encoder on gpu memory which is much more gpu-memory-efficient:

```python
from torch import nn


class MyModel(nn.Module):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.device = "cuda"
        self.encoder = MyEncoder().to(self.device)

        # move this to cpu, as we only need the encoder on gpu and we can use smaller gpus then
        self.decoder = MyDecoder(self.encoder).to("cpu")

    def forward(self, x):
        return self.decoder(self.encoder(x))


class MyEncoder(nn.Module):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.model = nn.Linear(64, 16)

        self.some_arg = 10

    def forward(self, x):
        return self.model(x)


class MyDecoder(nn.Module):
    def __init__(self, encoder, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.model = nn.Linear(16, 64)

        self.encoder_some_arg = encoder.some_arg

    def forward(self, x):
        print("some arg", self.encoder.encoder_some_arg)
        return self.model(x)


if __name__ == "__main__":
    my_model = MyModel()

    print(next(my_model.decoder.parameters()).device) # this is on cpu now
    print(next(my_model.encoder.parameters()).device) # and this can be separately loaded to gpu as needed
 ```

I adapted the code which should not lead to any changes in functionality as the `self.encoder` references are only used for strides and output_channels information whose information can be copied easily in the `__init__`.

I also plan to do a PR on the nnU-Net repo for adding the self-supervised learning functionality without any major code breaks. Would you be theoretically interested in merging this and extending the functionality?