### PR TITLE
refactor syntax to work with python < 3.11

### DIFF
--- a/dynamic_network_architectures/building_blocks/patch_encode_decode.py
+++ b/dynamic_network_architectures/building_blocks/patch_encode_decode.py
@@ -16,9 +16,12 @@ class LayerNormNd(nn.Module):
         u = x.mean(1, keepdim=True)
         s = (x - u).pow(2).mean(1, keepdim=True)
         x = (x - u) / torch.sqrt(s + self.eps)
+        # Create proper indexing tuple for broadcasting
+        weight_shape = [1, -1] + [1] * (x.ndim - 2)
+        bias_shape = [1, -1] + [1] * (x.ndim - 2)
         x = (
-            self.weight[None, :, *tuple([None] * (x.ndim - 2))] * x
-            + self.bias[None, :, *tuple([None] * (x.ndim - 2))]
+            self.weight.view(weight_shape) * x
+            + self.bias.view(bias_shape)
         )
         return x
 


### PR DESCRIPTION
The more recent nnunetv2 versions do not work with python < 3.11 anymore. This simple syntax change makes it work again. Often it can be tricky to update to a newer version of python because of other libraries which do not properly work yet on newer python versions. Therefore, if easily possible it makes life of developers a lot easier if a wide range of python versions is supported.