### PR TITLE
Replace torch.linspace with np.linspace

### DIFF
--- a/dynamic_network_architectures/building_blocks/eva.py
+++ b/dynamic_network_architectures/building_blocks/eva.py
@@ -104,7 +104,7 @@ class Eva(nn.Module):
         else:
             self.rope = None
 
-        dpr = [x.item() for x in torch.linspace(0, drop_path_rate, depth)]  # stochastic depth decay rule
+        dpr = np.linspace(0, drop_path_rate, depth)  # stochastic depth decay rule
         block_fn = block_fn
         self.blocks = nn.ModuleList(
             [


### PR DESCRIPTION
This allows to initialize models in the ["meta" device](https://docs.pytorch.org/docs/stable/meta.html), which is >10× faster, if desired.

```python
import torch

from dynamic_network_architectures.architectures.primus import Primus

def initialize_primus():
    return Primus(1, 864, 3 * (8,), 2, input_shape=3 * (160,))
```

```python
%%timeit
initialize_primus()
```

```
2.45 s ± 38 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

```python
%%timeit
with torch.device("meta"):
    initialize_primus()
```

```
195 ms ± 871 μs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```