### PR TITLE
Fix Loading Saved Models with Transformers

### DIFF
--- a/dynamic_network_architectures/initialization/weight_init.py
+++ b/dynamic_network_architectures/initialization/weight_init.py
@@ -9,9 +9,9 @@ class InitWeights_He(object):
 
     def __call__(self, module):
         if isinstance(module, nn.Conv3d) or isinstance(module, nn.Conv2d) or isinstance(module, nn.ConvTranspose2d) or isinstance(module, nn.ConvTranspose3d):
-            module.weight = nn.init.kaiming_normal_(module.weight, a=self.neg_slope)
+            nn.init.kaiming_normal_(module.weight, a=self.neg_slope)
             if module.bias is not None:
-                module.bias = nn.init.constant_(module.bias, 0)
+                nn.init.constant_(module.bias, 0)
 
 
 class InitWeights_XavierUniform(object):
@@ -20,15 +20,15 @@ class InitWeights_XavierUniform(object):
 
     def __call__(self, module):
         if isinstance(module, nn.Conv3d) or isinstance(module, nn.Conv2d) or isinstance(module, nn.ConvTranspose2d) or isinstance(module, nn.ConvTranspose3d):
-            module.weight = nn.init.xavier_uniform_(module.weight, self.gain)
+            nn.init.xavier_uniform_(module.weight, self.gain)
             if module.bias is not None:
-                module.bias = nn.init.constant_(module.bias, 0)
+                nn.init.constant_(module.bias, 0)
 
 
 def init_last_bn_before_add_to_0(module):
     if isinstance(module, BasicBlockD):
-        module.conv2.norm.weight = nn.init.constant_(module.conv2.norm.weight, 0)
-        module.conv2.norm.bias = nn.init.constant_(module.conv2.norm.bias, 0)
+        nn.init.constant_(module.conv2.norm.weight, 0)
+        nn.init.constant_(module.conv2.norm.bias, 0)
     if isinstance(module, BottleneckD):
-        module.conv3.norm.weight = nn.init.constant_(module.conv3.norm.weight, 0)
-        module.conv3.norm.bias = nn.init.constant_(module.conv3.norm.bias, 0)
+        nn.init.constant_(module.conv3.norm.weight, 0)
+        nn.init.constant_(module.conv3.norm.bias, 0)


### PR DESCRIPTION
Thanks for the repo! 

I was trying to use a Primus model as part of a [`transformers`](https://huggingface.co/docs/transformers/index) model. However, when loading saved checkpoints `transformers` uses this context manager [`no_init_weights`](https://github.com/huggingface/transformers/blob/91be12bdc6d312a2d7a44174971f025c4023a91f/src/transformers/modeling_utils.py#L228-L250) which makes all parameter initialisation function not do anything nor return anything. 

This breaks a few lines like this:
```python
module.weight = nn.init.kaiming_normal_(module.weight, a=self.neg_slope)
```
since `module.weight` gets assigned `None`.

This can be fixed by removing the assignment since this operation happens in place:
```python
nn.init.kaiming_normal_(module.weight, a=self.neg_slope)
```
